### PR TITLE
Move build-dotnet6-0.properties.json

### DIFF
--- a/build-dotnet6-0.properties.json
+++ b/build-dotnet6-0.properties.json
@@ -1,4 +1,0 @@
-{
-    "name": "York Trials Unit .NET Build and Test",
-    "description": "Build and test a .NET or ASP.NET Core project."
-}

--- a/workflow-templates/build-dotnet6-0.properties.json
+++ b/workflow-templates/build-dotnet6-0.properties.json
@@ -1,0 +1,4 @@
+{
+    "name": "York Trials Unit .NET Build and Test",
+    "description": "Build and test a .NET or ASP.NET Core project."
+}


### PR DESCRIPTION
**Issue:**
Dotnet 6 workflow properties file is in the wrong directory.

**Fix:**
Moved build-dotnet6-0.properties.json to the correct directory.

**Suggested Testing**
Once merged confirm that the workflow is available under "By york trials unit"
![image](https://github.com/uoy-trials/.github/assets/82442785/992c7ca1-bed0-4985-bd00-f54c8ee608ff)