### PR TITLE
Ensure this repo is suitable to be public

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2024 The University of York.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ A special repository used for templating files on behalf of repositories within 
 - Repo-Quality-Rating: 5
 - Repo-Next-Review-Due: 2025-05-02
 - Repo-Expected-Retirement-Date: 
+
+
+Copyright © 2024 The University of York. All Rights Reserved.


### PR DESCRIPTION
**Issue:**
Run thoguh some checks to make sure this repo attains the standards of a UoY public repo.

Detailed information can be found [on the wiki page](https://uoy.atlassian.net/wiki/spaces/SEDP/pages/76777888/Public+github+repositories) but the summary is as follows:
[Redacted - see issue]

**Fix:**
- Manually checked validity of code and what is being exposed. 
  - It's a very small repo with 2 template workflow YAML files in it Nothing has any danger of being made public. Nothing identifying is exposed, outside of the organisation repo name which is visible anyway (ie uoy-trials).
- I made sure the README file adheres to the new UoY standard (issue #15) and asserts ownership by UoY
- Added a standard MIT License file.
- Ensured no conflict of other peoples code or conflicting license

**Notes**
The only part that hasn't been done is the

> Changing the visibility of a repository to Public is a decision that must be separately recorded by the person responsible for the decision. This must include a confirmation that this policy has been complied with in making that decision.

Seperatly recorded would imply documenting this somewhere outside of GitHub. The person responsible for the decision is tp1045 as noted in [this slack thread](https://uoy-dohs.slack.com/archives/C01J43F94NP/p1689000671389169).

**Suggested Testing**
Read the README.md and LICENSE.md and make sure you're ahppy with the contents (Proper readme format, attrubition, license).
Quickly skim the code (all 4 files!) and check there is nothing that breaches point 2.7 "Do not make public what must be kept private".

ChaReq link: None

closes #16 
